### PR TITLE
feat: add backup toggle functionality

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,7 @@ interactive interface for login.
 | api-key / a | false |  | set an API key to use for login (useful if you require a non interactive login) |
 | api-username / u | false | | required if api-key is set, the username for the user the api key belongs to |
 | no-keep-existing | false | false | dont keep existing npmrc lines, only write new artifactory lines (defaults to keeping existing npmrc lines, commenting out matching scopes) |
+| skip-backup | false | false | skips keeping a backup of existing npmrc files at the same path as specified by the npmrc-path option |
 | npmrc-path / p | false | ~/.npmrc | path to the npmrc file to replace/update (defaults to .npmrc in home directory) |
 | no-interactive | false | | skip loading all interactive elements (for use in CI), you must supply a valid api-key to use this option |
 | help / h | false | | show help text |

--- a/lib/functionality.js
+++ b/lib/functionality.js
@@ -59,6 +59,7 @@ function getOptions(inputOpts) {
         opts.host = url.host;
 
         opts['keep-existing'] = !opts['no-keep-existing'];
+        opts['keep-backup'] = !opts['skip-backup'];
 
         opts.path = opts['npmrc-path'] ? path.resolve(opts['npmrc-path']) : path.resolve(homedir, '.npmrc');
 
@@ -170,7 +171,7 @@ function formatNPMRC(data) {
 function writeNPMRC(data) {
     return checkIfNpmrcExists()
         .then(exists => {
-            if (exists) {
+            if (exists && opts['keep-backup']) {
                 return backupExistingNpmrc()
                     .then(commentOutExistingScopes);
             }

--- a/options.js
+++ b/options.js
@@ -32,6 +32,11 @@ module.exports = [
         description: '[Optional] dont keep existing npmrc lines, only write new artifactory lines (defaults to keeping existing npmrc lines, commenting out matching scopes)'
     },
     {
+        name: 'skip-backup',
+        type: Boolean,
+        description: '[Optional] skip creating a backup of existing npmrc files at the same path as specified by the npmrc-path option (defaults to keeping backup)'
+    },
+    {
         name: 'npmrc-path',
         alias: 'p',
         type: String,


### PR DESCRIPTION
There are cases where we may not want to backup existing npmrc files as it can create clutter when we use this package to generate an npmrc on startup on a machine thats already run the package before.

This PR adds the ability to toggle the backup on and off.